### PR TITLE
fix(saveRoute):新スポット作成せず経路保存 feat(deleteUser):ユーザ削除で自動的にスポットと経路も削除される

### DIFF
--- a/backend/src/controllers/RouteController.js
+++ b/backend/src/controllers/RouteController.js
@@ -42,6 +42,12 @@ class RouteController {
           message: '目的地情報が必要です'
         });
       }
+
+      // 出発地・目的地の緯度・経度をそれぞれ取得
+      const originLat = origin.lat;
+      const originLng = origin.lng;
+      const destinationLat = destination.lat;
+      const destinationLng = destination.lng;
       
       // ユーザーIDの取得（認証済みの場合）
       const userId = (req.user && req.user.id) || req.body.userId || null;
@@ -56,7 +62,11 @@ class RouteController {
           name,
           description,
           routeType,
-          detourLevel
+          detourLevel,
+          originLat, // 出発地の緯度
+          originLng, // 出発地の経度
+          destinationLat, // 目的地の緯度
+          destinationLng, // 目的地の経度
         },
         { userId }
       );

--- a/backend/src/db/migrations/003-create-routes-table.sql
+++ b/backend/src/db/migrations/003-create-routes-table.sql
@@ -1,29 +1,36 @@
 -- ファイル名: backend/src/db/migrations/003-create-routes-table.sql
 CREATE TABLE routes (
   id SERIAL PRIMARY KEY,
+  userId INTEGER NOT NULL,
   name VARCHAR(100) NOT NULL,
   description TEXT,
-  origin_id INTEGER NOT NULL REFERENCES places(id) ON DELETE CASCADE,
-  destination_id INTEGER NOT NULL REFERENCES places(id) ON DELETE CASCADE,
-  user_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
+  origin_lat DECIMAL(10, 7) NOT NULL,  -- 出発地の緯度
+  origin_lng DECIMAL(10, 7) NOT NULL,  -- 出発地の経度
+  destination_lat DECIMAL(10, 7) NOT NULL,  -- 目的地の緯度
+  destination_lng DECIMAL(10, 7) NOT NULL,  -- 目的地の経度
   distance INTEGER,  -- メートル単位
   duration INTEGER,  -- 秒単位
   created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-  updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT fk_user FOREIGN KEY (userId) REFERENCES users(id) ON DELETE CASCADE
+
 );
 
 -- 経由地点のテーブル（中間テーブル）
 CREATE TABLE route_waypoints (
   id SERIAL PRIMARY KEY,
-  route_id INTEGER NOT NULL REFERENCES routes(id) ON DELETE CASCADE,
-  place_id INTEGER NOT NULL REFERENCES places(id) ON DELETE CASCADE,
+  route_id INTEGER NOT NULL,
+  place_id INTEGER NOT NULL,
   sequence INTEGER NOT NULL, -- 経由順序
-  UNIQUE (route_id, sequence) -- 同じルート内で同じ順序を持つ経由地点がないことを保証
+  UNIQUE (route_id, sequence), -- 同じルート内で同じ順序を持つ経由地点がないことを保証
+  CONSTRAINT fk_route FOREIGN KEY (route_id) REFERENCES routes(id) ON DELETE CASCADE,
+  CONSTRAINT fk_place FOREIGN KEY (place_id) REFERENCES places(id) ON DELETE CASCADE
 );
 
 -- インデックスの作成
 CREATE INDEX idx_routes_name ON routes(name);
-CREATE INDEX idx_routes_user ON routes(user_id);
-CREATE INDEX idx_routes_origin_dest ON routes(origin_id, destination_id);
+CREATE INDEX idx_routes_user ON routes(userId);
+CREATE INDEX idx_routes_origin_dest ON routes(origin_lat, origin_lng, destination_lat, destination_lng);
 CREATE INDEX idx_route_waypoints_route ON route_waypoints(route_id);
 CREATE INDEX idx_route_waypoints_place ON route_waypoints(place_id);

--- a/backend/src/repositories/RouteRepository.js
+++ b/backend/src/repositories/RouteRepository.js
@@ -41,9 +41,11 @@ class RouteRepository extends BaseRepository {
       console.log('🔧 保存前データ確認:', {
         distance: routeData.distance,
         duration: routeData.duration,
-        origin_id: routeData.origin_id,
-        destination_id: routeData.destination_id,
-        user_id: routeData.user_id,
+        origin_lat: parseFloat(routeData.origin_lat),
+        origin_lng: parseFloat(routeData.origin_lng),
+        destination_lat: parseFloat(routeData.destination_lat),
+        destination_lng: parseFloat(routeData.destination_lng),
+        userId: routeData.userId,
         detour_level: routeData.detour_level
       });
 
@@ -53,7 +55,7 @@ class RouteRepository extends BaseRepository {
         description: routeData.description || '',
         origin_id: this._safeParseInt(routeData.origin_id),
         destination_id: this._safeParseInt(routeData.destination_id),
-        user_id: routeData.user_id ? this._safeParseInt(routeData.user_id) : null,
+        userId: routeData.userId ? this._safeParseInt(routeData.userId) : null,
         distance: this._safeParseInt(routeData.distance),      // 💡 これがエラーの原因だった
         duration: this._safeParseInt(routeData.duration),      // 💡 これも変換が必要
         geometry: routeData.geometry || null,
@@ -75,31 +77,29 @@ class RouteRepository extends BaseRepository {
         throw new Error(`Invalid route data: distance=${safeRouteData.distance}, duration=${safeRouteData.duration}`);
       }
 
-      if (safeRouteData.origin_id <= 0 || safeRouteData.destination_id <= 0) {
-        throw new Error(`Invalid place IDs: origin=${safeRouteData.origin_id}, destination=${safeRouteData.destination_id}`);
-      }
-
       // ルート保存
       const routeQuery = `
         INSERT INTO routes (
-          name, description, origin_id, destination_id, user_id,
-          distance, duration, geometry, detour_level, route_type, overview_polyline
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) 
+          name, description, origin_lat, origin_lng, destination_lat, destination_lng,
+          userId, distance, duration, geometry, detour_level, route_type, overview_polyline
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13) 
         RETURNING *
       `;
       
       const routeValues = [
-        safeRouteData.name,
-        safeRouteData.description,
-        safeRouteData.origin_id,
-        safeRouteData.destination_id,
-        safeRouteData.user_id,
-        safeRouteData.distance,        // 💡 整数変換済み
-        safeRouteData.duration,        // 💡 整数変換済み
-        safeRouteData.geometry,
-        safeRouteData.detour_level,    // 💡 整数変換済み
-        safeRouteData.route_type,
-        safeRouteData.overview_polyline
+        routeData.name,
+        routeData.description,
+        parseFloat(routeData.origin_lat),
+        parseFloat(routeData.origin_lng),
+        parseFloat(routeData.destination_lat),
+        parseFloat(routeData.destination_lng),
+        routeData.userId,
+        this._safeParseInt(routeData.distance),
+        this._safeParseInt(routeData.duration),
+        routeData.geometry,
+        this._safeParseInt(routeData.detour_level),
+        routeData.route_type,
+        routeData.overview_polyline
       ];
       
       console.log('📝 実行クエリパラメータ（型確認）:', 
@@ -188,7 +188,6 @@ class RouteRepository extends BaseRepository {
       const stepsResult = await this.pool.query(stepsQuery, [id]);
       
       route.steps = stepsResult.rows;
-      
       return route;
     } catch (error) {
       console.error(`経路(ID: ${id})の詳細取得エラー:`, error);
@@ -205,9 +204,7 @@ class RouteRepository extends BaseRepository {
                p1.name as origin_name, p1.lat as origin_lat, p1.lng as origin_lng,
                p2.name as destination_name, p2.lat as destination_lat, p2.lng as destination_lng
         FROM routes r
-        LEFT JOIN places p1 ON r.origin_id = p1.id
-        LEFT JOIN places p2 ON r.destination_id = p2.id
-        WHERE r.user_id = $1
+        WHERE r.userId = $1
         ORDER BY r.created_at DESC
         LIMIT $2 OFFSET $3
       `;

--- a/backend/src/services/routeService.js
+++ b/backend/src/services/routeService.js
@@ -64,8 +64,8 @@ class RouteService {
       const destinationData = await this._resolveLocation(routeData.destination, options.userId);
       
       console.log('📍 場所解決結果:', {
-        origin: { id: originData.place.id, name: originData.place.name },
-        destination: { id: destinationData.place.id, name: destinationData.place.name }
+        origin: originData.coords,
+        destination: destinationData.coords
       });
       
       // 2. 経由地の処理
@@ -113,11 +113,15 @@ class RouteService {
       
       // 7. 経路データの準備
       const routeToSave = {
-        name: routeData.name || `${originData.place.name || '出発地'} から ${destinationData.place.name || '目的地'} への経路`,
+        name: routeData.name || '新しい経路',
         description: routeData.description || '',
-        origin_id: originData.place.id,        // ✅ 実際のDBのID
-        destination_id: destinationData.place.id, // ✅ 実際のDBのID
         userId: options.userId || null,
+
+        // ✅ 緯度経度を直接保存
+        origin_lat: parseFloat(originData.coords.lat),
+        origin_lng: parseFloat(originData.coords.lng),
+        destination_lat: parseFloat(destinationData.coords.lat),
+        destination_lng: parseFloat(destinationData.coords.lng),
         
         // 検証済みの計算結果データ
         distance: validatedRouteData.distance,
@@ -128,6 +132,7 @@ class RouteService {
         route_type: routeData.routeType || this.routeTypes.NORMAL,
         detour_level: routeData.detourLevel || 1,
         
+        //必要に応じて修正
         waypoints: waypointPlaces.map((place, index) => ({
           place_id: place.id,
           sequence: index + 1
@@ -146,7 +151,7 @@ class RouteService {
         maneuver: step.maneuver || null
       })) : [];
 
-      console.log('💾 データベース保存開始:', {
+      /*console.log('💾 データベース保存開始:', {
         routeData: {
           origin_id: routeToSave.origin_id,
           destination_id: routeToSave.destination_id,
@@ -154,7 +159,7 @@ class RouteService {
           duration: routeToSave.duration
         },
         stepsCount: processedSteps.length
-      });
+      });*/
       
       // 9. RouteRepositoryを使って経路とステップを保存
       const savedRoute = await this.routeRepository.createWithSteps(
@@ -199,43 +204,19 @@ class RouteService {
     
     // 座標オブジェクトの場合
     if (location.lat !== undefined && location.lng !== undefined) {
-      try {
-        // ✅ 修正：実際のデータベースに場所を作成
-        const place = await placeService.findOrCreatePlaceByCoordinates({
-          lat: parseFloat(location.lat),
-          lng: parseFloat(location.lng),
-          name: location.name,
-          userId: userId
-        });
-        
-        console.log('✅ 座標から場所作成/取得成功:', place);
-        
-        return {
-          place: place,
-          coords: { lat: location.lat, lng: location.lng }
-        };
-      } catch (error) {
-        console.error('❌ 座標からの場所作成エラー:', error);
-        throw new Error('場所の作成に失敗しました: ' + error.message);
-      }
+      return {
+        place: null,
+        coords: { lat: location.lat, lng: location.lng }
+      };
     }
     
     // 場所IDの場合
     if (typeof location === 'number' || (typeof location === 'string' && !isNaN(location))) {
-      try {
-        // ✅ 修正：実際のデータベースから場所を取得
         const place = await placeService.getPlaceById(parseInt(location));
-        
-        console.log('✅ IDから場所取得成功:', place);
-        
         return {
           place: place,
           coords: { lat: place.lat, lng: place.lng }
         };
-      } catch (error) {
-        console.error('❌ 場所取得エラー:', error);
-        throw new Error('指定された場所が見つかりません: ' + error.message);
-      }
     }
     
     throw new Error('不正な場所フォーマットです');

--- a/tests/api/places.http
+++ b/tests/api/places.http
@@ -2,7 +2,7 @@
 @baseUrl = http://localhost:3001/api
 
 ### 場所一覧を取得
-GET {{baseUrl}}/places/4
+GET {{baseUrl}}/places
 Content-Type: application/json
 
 ### ページネーションとソートで場所一覧を取得
@@ -64,9 +64,9 @@ POST {{baseUrl}}/places
 Content-Type: application/json
 
 {
-  "name": "ユーザー1 - 最初のテストスポット",
-  "userId": "1",
-  "description": "これはユーザー1が作成した最初のテストスポットです。",
+  "name": "ユーザー3 - 最初のテストスポット",
+  "userId": "3",
+  "description": "これはユーザー3が作成した最初のテストスポットです。",
   "category": "テスト",
   "address": "東京都新宿区西新宿2-8-1",
   "prefecture": "東京都",
@@ -81,9 +81,9 @@ POST {{baseUrl}}/places
 Content-Type: application/json
 
 {
-  "name": "ユーザー1 - 二番目のテストスポット",
-  "userId": "1",
-  "description": "これはユーザー1が作成した二番目のテストスポットです。",
+  "name": "ユーザー3 - 二番目のテストスポット",
+  "userId": "3",
+  "description": "これはユーザー3が作成した2番目のテストスポットです。",
   "category": "テスト",
   "address": "東京都渋谷区神宮前1-8-8",
   "prefecture": "東京都",

--- a/tests/api/routes-calculation.http
+++ b/tests/api/routes-calculation.http
@@ -103,7 +103,7 @@ Content-Type: application/json
 {
   "name": "新しい経路",
   "description": "テスト用ルート",
-  "userId": 1,
+  "userId": 3,
   "origin": {
     "lat": 35.6812,
     "lng": 139.7671

--- a/tests/api/users.http
+++ b/tests/api/users.http
@@ -18,8 +18,8 @@ POST {{baseUrl}}/users
 Content-Type: application/json
 
 {
-  "username": "testuser",
-  "email": "test@example.com",
+  "username": "testuser2",
+  "email": "test@example2.com",
   "password": "password123",
   "first_name": "テスト",
   "last_name": "ユーザー",
@@ -40,5 +40,5 @@ Content-Type: application/json
 }
 
 ### ユーザーを削除
-DELETE {{baseUrl}}/users/12
+DELETE {{baseUrl}}/users/1
 Content-Type: application/json


### PR DESCRIPTION
・経路を保存する際に、出発地と目的地がそれぞれ新しい保存スポットとしてDBに登録されてしまうバグを修正
　出発地および目的地の緯度・経度は、routes テーブルに直接保存するように変更

・ユーザーを削除した際に、そのユーザーに紐づく保存スポットおよび経路も自動的に削除される機能を追加
　places テーブルおよび routes テーブルにおいて、userId に対する外部キー制約に ON DELETE CASCADE を設定